### PR TITLE
feat: add request-level tracing to HTTP transports

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -29,10 +29,11 @@ func withLogging(logger *slog.Logger, name string, handler ToolHandler) ToolHand
 
 		// DEBUG: log full request args before handler execution
 		if logger.Enabled(ctx, slog.LevelDebug) {
+			var attrs []slog.Attr
+			attrs = append(attrs, requestAttrs(ctx)...)
 			argsJSON, _ := json.Marshal(request.GetRawArguments())
-			logger.LogAttrs(ctx, slog.LevelDebug, name+".request",
-				slog.String("args", string(argsJSON)),
-			)
+			attrs = append(attrs, slog.String("args", string(argsJSON)))
+			logger.LogAttrs(ctx, slog.LevelDebug, name+".request", attrs...)
 		}
 
 		result, err := handler(ctx, request)

--- a/logging.go
+++ b/logging.go
@@ -40,9 +40,13 @@ func withLogging(logger *slog.Logger, name string, handler ToolHandler) ToolHand
 
 		if err != nil {
 			var attrs []slog.Attr
+			attrs = append(attrs, requestAttrs(ctx)...)
 			if pe, ok := toolParamExtractors[name]; ok {
 				attrs = append(attrs, pe(request.GetArguments())...)
 			}
+			// Include raw args on error for debugging
+			argsJSON, _ := json.Marshal(request.GetRawArguments())
+			attrs = append(attrs, slog.String("raw_args", string(argsJSON)))
 			attrs = append(attrs, slog.Duration("duration", duration), slog.Any("error", err))
 			logger.LogAttrs(ctx, slog.LevelError, name, attrs...)
 			return result, err
@@ -53,6 +57,7 @@ func withLogging(logger *slog.Logger, name string, handler ToolHandler) ToolHand
 			return result, nil
 		}
 		var attrs []slog.Attr
+		attrs = append(attrs, requestAttrs(ctx)...)
 		if pe, ok := toolParamExtractors[name]; ok {
 			attrs = append(attrs, pe(request.GetArguments())...)
 		}

--- a/logging.go
+++ b/logging.go
@@ -44,9 +44,14 @@ func withLogging(logger *slog.Logger, name string, handler ToolHandler) ToolHand
 			if pe, ok := toolParamExtractors[name]; ok {
 				attrs = append(attrs, pe(request.GetArguments())...)
 			}
-			// Include raw args on error for debugging
-			argsJSON, _ := json.Marshal(request.GetRawArguments())
-			attrs = append(attrs, slog.String("raw_args", string(argsJSON)))
+			// Include truncated raw args on error for debugging malformed payloads
+			if argsJSON, merr := json.Marshal(request.GetRawArguments()); merr == nil {
+				s := string(argsJSON)
+				if len(s) > 512 {
+					s = s[:512] + "..."
+				}
+				attrs = append(attrs, slog.String("raw_args", s))
+			}
 			attrs = append(attrs, slog.Duration("duration", duration), slog.Any("error", err))
 			logger.LogAttrs(ctx, slog.LevelError, name, attrs...)
 			return result, err

--- a/main.go
+++ b/main.go
@@ -1450,8 +1450,8 @@ RETURNS: List of conflicts with entity name, both observations, and conflict typ
 			server.WithKeepAliveInterval(30*time.Second),
 			server.WithHTTPServer(customSrv),
 		)
-		mux.Handle("/sse", corsWrap(authWrap(sseServer.SSEHandler())))
-		mux.Handle("/message", corsWrap(authWrap(sseServer.MessageHandler())))
+		mux.Handle("/sse", requestCtxWrap(corsWrap(authWrap(sseServer.SSEHandler()))))
+		mux.Handle("/message", requestCtxWrap(corsWrap(authWrap(sseServer.MessageHandler()))))
 
 		slog.Info("SSE listening", "port", port)
 		// Start in background and handle graceful shutdown
@@ -1492,7 +1492,7 @@ RETURNS: List of conflicts with entity name, both observations, and conflict typ
 		mux := http.NewServeMux()
 		customSrv := &http.Server{Handler: mux}
 		streamSrv := server.NewStreamableHTTPServer(s, append(httpOpts, server.WithStreamableHTTPServer(customSrv))...)
-		mux.Handle(httpEndpoint, corsWrap(authWrap(streamSrv)))
+		mux.Handle(httpEndpoint, requestCtxWrap(corsWrap(authWrap(streamSrv))))
 
 		slog.Info("Streamable HTTP listening", "port", port, "endpoint", httpEndpoint)
 

--- a/requestctx.go
+++ b/requestctx.go
@@ -105,5 +105,13 @@ func truncate(s string, n int) string {
 	if len(s) <= n {
 		return s
 	}
-	return s[:n] + "..."
+	// Truncate at a rune boundary to avoid splitting multi-byte UTF-8.
+	cut := 0
+	for i := range s {
+		if i > n {
+			break
+		}
+		cut = i
+	}
+	return s[:cut] + "..."
 }

--- a/requestctx.go
+++ b/requestctx.go
@@ -81,6 +81,9 @@ func clientIPFrom(r *http.Request) string {
 	return host
 }
 
+// maxAttrLen caps logged header-sourced values to prevent log bloat.
+const maxAttrLen = 64
+
 // requestAttrs extracts request tracing metadata from context as slog attributes.
 // Returns nil if no request metadata is present (e.g., stdio transport).
 func requestAttrs(ctx context.Context) []slog.Attr {
@@ -90,10 +93,17 @@ func requestAttrs(ctx context.Context) []slog.Attr {
 	}
 	attrs := []slog.Attr{slog.String("req", reqID)}
 	if ip, _ := ctx.Value(ctxKeyClientIP).(string); ip != "" {
-		attrs = append(attrs, slog.String("ip", ip))
+		attrs = append(attrs, slog.String("ip", truncate(ip, maxAttrLen)))
 	}
 	if ua, _ := ctx.Value(ctxKeyUserAgent).(string); ua != "" {
-		attrs = append(attrs, slog.String("ua", ua))
+		attrs = append(attrs, slog.String("ua", truncate(ua, maxAttrLen)))
 	}
 	return attrs
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
 }

--- a/requestctx.go
+++ b/requestctx.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+)
+
+type ctxKey int
+
+const (
+	ctxKeyRequestID ctxKey = iota
+	ctxKeyClientIP
+	ctxKeyUserAgent
+)
+
+// requestCtxWrap injects request tracing metadata into the context:
+// request ID (from X-Request-ID header or generated), client IP, and User-Agent.
+func requestCtxWrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqID := r.Header.Get("X-Request-ID")
+		if reqID == "" {
+			reqID = generateRequestID()
+		}
+		w.Header().Set("X-Request-ID", reqID)
+
+		ctx := r.Context()
+		ctx = context.WithValue(ctx, ctxKeyRequestID, reqID)
+		ctx = context.WithValue(ctx, ctxKeyClientIP, clientIPFrom(r))
+		ctx = context.WithValue(ctx, ctxKeyUserAgent, r.Header.Get("User-Agent"))
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// generateRequestID produces a random 16-char hex string.
+func generateRequestID() string {
+	b := make([]byte, 8)
+	rand.Read(b)
+	return fmt.Sprintf("%x", b)
+}
+
+// clientIPFrom extracts the client IP from the request, checking
+// X-Forwarded-For, X-Real-IP, then RemoteAddr.
+func clientIPFrom(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if i := strings.IndexByte(xff, ','); i != -1 {
+			return strings.TrimSpace(xff[:i])
+		}
+		return strings.TrimSpace(xff)
+	}
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return xri
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// requestAttrs extracts request tracing metadata from context as slog attributes.
+// Returns nil if no request metadata is present (e.g., stdio transport).
+func requestAttrs(ctx context.Context) []slog.Attr {
+	reqID, _ := ctx.Value(ctxKeyRequestID).(string)
+	if reqID == "" {
+		return nil
+	}
+	attrs := []slog.Attr{slog.String("req", reqID)}
+	if ip, _ := ctx.Value(ctxKeyClientIP).(string); ip != "" {
+		attrs = append(attrs, slog.String("ip", ip))
+	}
+	if ua, _ := ctx.Value(ctxKeyUserAgent).(string); ua != "" {
+		attrs = append(attrs, slog.String("ua", ua))
+	}
+	return attrs
+}

--- a/requestctx.go
+++ b/requestctx.go
@@ -23,7 +23,7 @@ const (
 func requestCtxWrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		reqID := r.Header.Get("X-Request-ID")
-		if reqID == "" {
+		if !validRequestID(reqID) {
 			reqID = generateRequestID()
 		}
 		w.Header().Set("X-Request-ID", reqID)
@@ -37,10 +37,28 @@ func requestCtxWrap(next http.Handler) http.Handler {
 	})
 }
 
+// maxRequestIDLen is the maximum length accepted for an incoming X-Request-ID.
+const maxRequestIDLen = 128
+
+// validRequestID checks that an incoming request ID is non-empty, within the
+// length limit, and contains only printable ASCII (no control chars or newlines).
+func validRequestID(id string) bool {
+	if id == "" || len(id) > maxRequestIDLen {
+		return false
+	}
+	for _, c := range id {
+		if c < 0x20 || c > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
 // generateRequestID produces a random 16-char hex string.
+// On Go 1.22+ crypto/rand.Read always returns len(p), nil (panics on failure).
 func generateRequestID() string {
 	b := make([]byte, 8)
-	rand.Read(b)
+	_, _ = rand.Read(b)
 	return fmt.Sprintf("%x", b)
 }
 
@@ -53,7 +71,7 @@ func clientIPFrom(r *http.Request) string {
 		}
 		return strings.TrimSpace(xff)
 	}
-	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+	if xri := strings.TrimSpace(r.Header.Get("X-Real-IP")); xri != "" {
 		return xri
 	}
 	host, _, err := net.SplitHostPort(r.RemoteAddr)

--- a/requestctx_test.go
+++ b/requestctx_test.go
@@ -41,6 +41,44 @@ func TestGenerateRequestID(t *testing.T) {
 	})
 }
 
+func TestValidRequestID(t *testing.T) {
+	t.Run("accepts normal IDs", func(t *testing.T) {
+		for _, id := range []string{"abc123", "my-trace-123", "req_2024.01.01"} {
+			if !validRequestID(id) {
+				t.Errorf("expected valid: %q", id)
+			}
+		}
+	})
+
+	t.Run("rejects empty", func(t *testing.T) {
+		if validRequestID("") {
+			t.Error("empty should be invalid")
+		}
+	})
+
+	t.Run("rejects too long", func(t *testing.T) {
+		long := strings.Repeat("a", maxRequestIDLen+1)
+		if validRequestID(long) {
+			t.Error("over-length should be invalid")
+		}
+	})
+
+	t.Run("accepts max length", func(t *testing.T) {
+		exact := strings.Repeat("a", maxRequestIDLen)
+		if !validRequestID(exact) {
+			t.Error("exact max length should be valid")
+		}
+	})
+
+	t.Run("rejects control chars", func(t *testing.T) {
+		for _, id := range []string{"abc\n123", "abc\r\n123", "abc\x00def"} {
+			if validRequestID(id) {
+				t.Errorf("should reject control chars: %q", id)
+			}
+		}
+	})
+}
+
 func TestClientIPFrom(t *testing.T) {
 	t.Run("X-Forwarded-For single", func(t *testing.T) {
 		r := httptest.NewRequest("POST", "/mcp", nil)
@@ -117,6 +155,26 @@ func TestRequestCtxWrap(t *testing.T) {
 		}
 		if rec.Header().Get("X-Request-ID") != "my-trace-123" {
 			t.Error("response header should echo the incoming X-Request-ID")
+		}
+	})
+
+	t.Run("rejects invalid X-Request-ID and generates new", func(t *testing.T) {
+		var gotID string
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotID, _ = r.Context().Value(ctxKeyRequestID).(string)
+		})
+		handler := requestCtxWrap(inner)
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/mcp", nil)
+		req.Header.Set("X-Request-ID", "bad\nid")
+		handler.ServeHTTP(rec, req)
+
+		if gotID == "bad\nid" {
+			t.Error("should have rejected X-Request-ID with control chars")
+		}
+		if gotID == "" {
+			t.Error("should have generated a replacement ID")
 		}
 	})
 

--- a/requestctx_test.go
+++ b/requestctx_test.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGenerateRequestID(t *testing.T) {
+	t.Run("non-empty", func(t *testing.T) {
+		id := generateRequestID()
+		if id == "" {
+			t.Error("expected non-empty request ID")
+		}
+	})
+
+	t.Run("hex format 16 chars", func(t *testing.T) {
+		id := generateRequestID()
+		if len(id) != 16 {
+			t.Errorf("expected 16-char hex string, got %d chars: %q", len(id), id)
+		}
+		for _, c := range id {
+			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+				t.Errorf("non-hex character %c in request ID %q", c, id)
+			}
+		}
+	})
+
+	t.Run("unique across calls", func(t *testing.T) {
+		seen := make(map[string]bool)
+		for i := 0; i < 100; i++ {
+			id := generateRequestID()
+			if seen[id] {
+				t.Fatalf("duplicate request ID on iteration %d: %q", i, id)
+			}
+			seen[id] = true
+		}
+	})
+}
+
+func TestClientIPFrom(t *testing.T) {
+	t.Run("X-Forwarded-For single", func(t *testing.T) {
+		r := httptest.NewRequest("POST", "/mcp", nil)
+		r.Header.Set("X-Forwarded-For", "203.0.113.50")
+		if got := clientIPFrom(r); got != "203.0.113.50" {
+			t.Errorf("got %q, want 203.0.113.50", got)
+		}
+	})
+
+	t.Run("X-Forwarded-For chain takes first", func(t *testing.T) {
+		r := httptest.NewRequest("POST", "/mcp", nil)
+		r.Header.Set("X-Forwarded-For", "203.0.113.50, 10.0.0.1, 172.16.0.1")
+		if got := clientIPFrom(r); got != "203.0.113.50" {
+			t.Errorf("got %q, want 203.0.113.50", got)
+		}
+	})
+
+	t.Run("X-Real-IP fallback", func(t *testing.T) {
+		r := httptest.NewRequest("POST", "/mcp", nil)
+		r.Header.Set("X-Real-IP", "198.51.100.10")
+		if got := clientIPFrom(r); got != "198.51.100.10" {
+			t.Errorf("got %q, want 198.51.100.10", got)
+		}
+	})
+
+	t.Run("RemoteAddr fallback strips port", func(t *testing.T) {
+		r := httptest.NewRequest("POST", "/mcp", nil)
+		r.RemoteAddr = "192.168.1.100:54321"
+		if got := clientIPFrom(r); got != "192.168.1.100" {
+			t.Errorf("got %q, want 192.168.1.100", got)
+		}
+	})
+
+	t.Run("X-Forwarded-For takes priority over X-Real-IP", func(t *testing.T) {
+		r := httptest.NewRequest("POST", "/mcp", nil)
+		r.Header.Set("X-Forwarded-For", "203.0.113.50")
+		r.Header.Set("X-Real-IP", "198.51.100.10")
+		if got := clientIPFrom(r); got != "203.0.113.50" {
+			t.Errorf("got %q, want 203.0.113.50", got)
+		}
+	})
+}
+
+func TestRequestCtxWrap(t *testing.T) {
+	t.Run("sets X-Request-ID response header", func(t *testing.T) {
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		handler := requestCtxWrap(inner)
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/mcp", nil)
+		handler.ServeHTTP(rec, req)
+
+		if got := rec.Header().Get("X-Request-ID"); got == "" {
+			t.Error("expected X-Request-ID response header")
+		}
+	})
+
+	t.Run("honors incoming X-Request-ID", func(t *testing.T) {
+		var gotID string
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotID, _ = r.Context().Value(ctxKeyRequestID).(string)
+		})
+		handler := requestCtxWrap(inner)
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/mcp", nil)
+		req.Header.Set("X-Request-ID", "my-trace-123")
+		handler.ServeHTTP(rec, req)
+
+		if gotID != "my-trace-123" {
+			t.Errorf("got %q, want my-trace-123", gotID)
+		}
+		if rec.Header().Get("X-Request-ID") != "my-trace-123" {
+			t.Error("response header should echo the incoming X-Request-ID")
+		}
+	})
+
+	t.Run("generates ID when no header", func(t *testing.T) {
+		var gotID string
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotID, _ = r.Context().Value(ctxKeyRequestID).(string)
+		})
+		handler := requestCtxWrap(inner)
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/mcp", nil)
+		handler.ServeHTTP(rec, req)
+
+		if gotID == "" {
+			t.Error("expected generated request ID in context")
+		}
+	})
+
+	t.Run("propagates client IP", func(t *testing.T) {
+		var gotIP string
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotIP, _ = r.Context().Value(ctxKeyClientIP).(string)
+		})
+		handler := requestCtxWrap(inner)
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/mcp", nil)
+		req.Header.Set("X-Forwarded-For", "10.42.0.58")
+		handler.ServeHTTP(rec, req)
+
+		if gotIP != "10.42.0.58" {
+			t.Errorf("got %q, want 10.42.0.58", gotIP)
+		}
+	})
+
+	t.Run("propagates User-Agent", func(t *testing.T) {
+		var gotUA string
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotUA, _ = r.Context().Value(ctxKeyUserAgent).(string)
+		})
+		handler := requestCtxWrap(inner)
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/mcp", nil)
+		req.Header.Set("User-Agent", "claude-code/1.0")
+		handler.ServeHTTP(rec, req)
+
+		if gotUA != "claude-code/1.0" {
+			t.Errorf("got %q, want claude-code/1.0", gotUA)
+		}
+	})
+}
+
+func TestRequestAttrs(t *testing.T) {
+	t.Run("nil for empty context", func(t *testing.T) {
+		attrs := requestAttrs(context.Background())
+		if attrs != nil {
+			t.Errorf("expected nil attrs for empty context, got %v", attrs)
+		}
+	})
+
+	t.Run("returns attrs for populated context", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ctxKeyRequestID, "abc123")
+		ctx = context.WithValue(ctx, ctxKeyClientIP, "10.0.0.1")
+		ctx = context.WithValue(ctx, ctxKeyUserAgent, "test-agent")
+
+		attrs := requestAttrs(ctx)
+		if len(attrs) != 3 {
+			t.Fatalf("expected 3 attrs, got %d", len(attrs))
+		}
+		// req, ip, ua
+		if attrs[0].Key != "req" || attrs[0].Value.String() != "abc123" {
+			t.Errorf("unexpected req attr: %v", attrs[0])
+		}
+		if attrs[1].Key != "ip" || attrs[1].Value.String() != "10.0.0.1" {
+			t.Errorf("unexpected ip attr: %v", attrs[1])
+		}
+		if attrs[2].Key != "ua" || attrs[2].Value.String() != "test-agent" {
+			t.Errorf("unexpected ua attr: %v", attrs[2])
+		}
+	})
+
+	t.Run("omits empty ip and ua", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), ctxKeyRequestID, "abc123")
+		attrs := requestAttrs(ctx)
+		if len(attrs) != 1 {
+			t.Fatalf("expected 1 attr (req only), got %d", len(attrs))
+		}
+	})
+}
+
+func TestLoggingWithRequestContext(t *testing.T) {
+	t.Run("includes req ID in info log", func(t *testing.T) {
+		logger, buf := testLogger(slog.LevelInfo)
+		wrapped := withLogging(logger, "read_graph", successHandler(`{"totalEntities":5}`))
+
+		ctx := context.WithValue(context.Background(), ctxKeyRequestID, "trace-42")
+		ctx = context.WithValue(ctx, ctxKeyClientIP, "10.0.0.1")
+		wrapped(ctx, makeRequest(map[string]any{"mode": "summary"}))
+
+		output := buf.String()
+		if !strings.Contains(output, "req=trace-42") {
+			t.Errorf("expected req=trace-42 in log: %s", output)
+		}
+		if !strings.Contains(output, "ip=10.0.0.1") {
+			t.Errorf("expected ip=10.0.0.1 in log: %s", output)
+		}
+	})
+
+	t.Run("includes req ID in error log", func(t *testing.T) {
+		logger, buf := testLogger(slog.LevelInfo)
+		wrapped := withLogging(logger, "open_nodes", errorHandler("not found"))
+
+		ctx := context.WithValue(context.Background(), ctxKeyRequestID, "trace-99")
+		wrapped(ctx, makeRequest(nil))
+
+		output := buf.String()
+		if !strings.Contains(output, "req=trace-99") {
+			t.Errorf("expected req=trace-99 in error log: %s", output)
+		}
+	})
+
+	t.Run("includes raw_args in error log", func(t *testing.T) {
+		logger, buf := testLogger(slog.LevelInfo)
+		wrapped := withLogging(logger, "open_nodes", errorHandler("invalid arguments: bad"))
+
+		wrapped(context.Background(), makeRequest(map[string]any{"names": "Scout"}))
+
+		output := buf.String()
+		if !strings.Contains(output, "raw_args=") {
+			t.Errorf("expected raw_args in error log: %s", output)
+		}
+		if !strings.Contains(output, "Scout") {
+			t.Errorf("expected Scout in raw_args: %s", output)
+		}
+	})
+
+	t.Run("no req field for stdio context", func(t *testing.T) {
+		logger, buf := testLogger(slog.LevelInfo)
+		wrapped := withLogging(logger, "read_graph", successHandler(`{"totalEntities":1}`))
+		wrapped(context.Background(), makeRequest(map[string]any{"mode": "summary"}))
+
+		if strings.Contains(buf.String(), "req=") {
+			t.Errorf("should not have req= for bare context: %s", buf.String())
+		}
+	})
+}

--- a/requestctx_test.go
+++ b/requestctx_test.go
@@ -259,6 +259,28 @@ func TestRequestAttrs(t *testing.T) {
 		}
 	})
 
+	t.Run("truncates long ua", func(t *testing.T) {
+		longUA := strings.Repeat("x", 200)
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ctxKeyRequestID, "abc")
+		ctx = context.WithValue(ctx, ctxKeyUserAgent, longUA)
+
+		attrs := requestAttrs(ctx)
+		for _, a := range attrs {
+			if a.Key == "ua" {
+				got := a.Value.String()
+				if len(got) > maxAttrLen+3 { // +3 for "..."
+					t.Errorf("ua not truncated: len=%d", len(got))
+				}
+				if !strings.HasSuffix(got, "...") {
+					t.Error("truncated ua should end with ...")
+				}
+				return
+			}
+		}
+		t.Error("expected ua attr")
+	})
+
 	t.Run("omits empty ip and ua", func(t *testing.T) {
 		ctx := context.WithValue(context.Background(), ctxKeyRequestID, "abc123")
 		attrs := requestAttrs(ctx)


### PR DESCRIPTION

## Changes

Inject request ID, client IP, and User-Agent into context via middleware so every tool log line includes tracing metadata. On error, raw request args are included for debugging malformed payloads.


## Verification

- [x] `make fmt && make check && go test ./... && make build` passes
- [x] Changes are scoped to the issue — no unrelated modifications
